### PR TITLE
add .gitattributes - fix project marked as html

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+about.html linguist-vendored


### PR DESCRIPTION
https://github.com/github/linguist#overrides

Many of your github repos are marked as "html" on github, simply because they contain more lines of html than lisp. 
https://github.com/Shinmera?utf8=✓&tab=repositories&q=&type=source&language=html
That's not practical to explore GH projects and a shame for CL stats :] 
Then my 2 cents.