### PR TITLE
Implement a migration system

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,7 +290,16 @@ The environment also allows administrator overrides. Using the `:static` and `:t
 
 See `environment-change`, `environment`, `environment-directory`, `environment-module-directory`, `environment-module-pathname`, `check-environment`, `mconfig-pathname`, `mconfig-storage`, `mconfig`, `defaulted-mconfig`, `config`, `defaulted-config`, `template-file`, `@template`, `static-file`, `@static`
 
-### 1.12 Instance Management
+### 1.12 Migration System
+Sometimes systems evolve in backwards incompatible ways. In that case, for existing setups to continue functioning with the new version, runtime data migration is necessary. Radiance offers a system to automate this process and allow a smooth upgrade. 
+
+The migration between versions should occur automatically during Radiance's startup sequence. As an administrator or author you should not need to perform any additional steps for migrations to occur. However, as a module author, you will naturally have to provide the code to perform the necessary data migration steps for your module.
+
+In order for a module to be migratable, it needs to be loaded by an ASDF system that has a version specification. The version should follow the standard dotted number scheme, with an optional version hash that can be added at the end. You may then define migration steps between individual versions by using `define-version-migration`. Once defined, Radiance will automatically pick up on concrete versions and perform the necessary migrations in sequence to reach the current target version. For more information on the precise procedure and what you can do, see `migrate` and `migrate-versions`.
+
+See `last-known-system-version`, `migrate-versions`, `define-version-migration`, `ready-dependency-for-migration`, `ensure-dependencies-ready`, `versions`, `migrate`
+
+### 1.13 Instance Management
 Finally, Radiance provides a standard startup and shutdown sequence that should ensure things are properly setup and readied, and afterwards cleaned up nicely again. A large part of that sequence is just ensuring that certain hooks are called in the proper order and at the appropriate times.
 
 While you can start a server manually by using the appropriate interface function, you should not expect applications to run properly if you do it that way. Many of them will expect certain hooks to be called in order to work properly. This is why you should always, unless you exactly know what you're doing, use `startup` and `shutdown` to manage a Radiance instance. The documentation of the two functions should explain exactly which hooks are triggered and in which order. An implementation may provide additional, unspecified definitions on symbols in the interface package, as long as said symbols are not exported.

--- a/conditions.lisp
+++ b/conditions.lisp
@@ -23,6 +23,17 @@
                                     This definition may lead to unintended overrides.~@[~%~a~]"
                                  (message c)))))
 
+(define-condition system-has-no-version (radiance-error)
+  ((system :initarg :system :initform (error "SYSTEM required.")))
+  (:report (lambda (c s) (format s "The system ~a has no version specified, so Radiance does not know how to migrate it to the latest point."
+                                 (asdf:component-name (slot-value c 'system))))))
+
+(define-condition backwards-migration-not-allowed (radiance-error)
+  ((from :initarg :from :initform (error "FROM required."))
+   (to :initarg :to :initform (error "TO required.")))
+  (:report (lambda (c s) (format s "Cannot migrate a system backwards from ~a to ~a."
+                                 (encode-version (slot-value c 'from)) (encode-version (slot-value c 'to))))))
+
 (define-condition environment-not-set (radiance-error) ()
   (:report "The application environment was not yet set but is required.
 This means you are either using Radiance for the first time or forgot to set it up properly.

--- a/defaults.lisp
+++ b/defaults.lisp
@@ -229,7 +229,7 @@
                ;; Other refer, no change.
                ))))))
 
-;;; Default logger to make sure we can log even before the real impl is laoded.
+;;; Default logger to make sure we can log even before the real impl is loaded.
 (defun l:log (level category log-string &rest format-args)
   (format *error-output* "~&~a [~a] <~a> ~?~%"
           (format-human-date (get-universal-time)) level category log-string format-args))

--- a/defaults.lisp
+++ b/defaults.lisp
@@ -228,3 +228,29 @@
               (T
                ;; Other refer, no change.
                ))))))
+
+;;; Default logger to make sure we can log even before the real impl is laoded.
+(defun l:log (level category log-string &rest format-args)
+  (format *error-output* "~&~a [~a] <~a> ~?"
+          (format-human-date (get-universal-time)) level category log-string format-args))
+
+(defun l:trace (category log-string &rest format-args)
+  (declare (ignore category log-string format-args)))
+
+(defun l:debug (category log-string &rest format-args)
+  (declare (ignore category log-string format-args)))
+
+(defun l:info (category log-string &rest format-args)
+  (apply #'l:log :info category log-string format-args))
+
+(defun l:warn (category log-string &rest format-args)
+  (apply #'l:log :warn category log-string format-args))
+
+(defun l:error (category log-string &rest format-args)
+  (apply #'l:log :error category log-string format-args))
+
+(defun l:severe (category log-string &rest format-args)
+  (apply #'l:log :severe category log-string format-args))
+
+(defun l:fatal (category log-string &rest format-args)
+  (apply #'l:log :fatal category log-string format-args))

--- a/defaults.lisp
+++ b/defaults.lisp
@@ -231,7 +231,7 @@
 
 ;;; Default logger to make sure we can log even before the real impl is laoded.
 (defun l:log (level category log-string &rest format-args)
-  (format *error-output* "~&~a [~a] <~a> ~?"
+  (format *error-output* "~&~a [~a] <~a> ~?~%"
           (format-human-date (get-universal-time)) level category log-string format-args))
 
 (defun l:trace (category log-string &rest format-args)

--- a/documentation.lisp
+++ b/documentation.lisp
@@ -1380,7 +1380,7 @@ See VERSION-PART=
 See VERSION-PART<")
 
   (function version-region
-    "Returns the subsequence of VERSIONS that are denoted by start and end.
+    "Returns the versions in VERSIONS that are between START and END, inclusive.
 
 For instance, the version list '(1 2 4 5 6) for the bounds 3 and 6
 would return '(4 5 6).
@@ -1390,7 +1390,7 @@ The list of versions is assumed to be sorted by VERSION<.
 See VERSION<=")
 
   (function version-bounds
-    "Returns a subsequence of VERSIONS that is bounded by start and end.
+    "Returns the versions in VERSIONS that are between START and END, inclusive, ensuring the sequence starts with START and ends with END, if provided.
 
 For instance, the version list '(1 2 4 5 6) for the bounds 3 and 6
 would return '(3 4 5 6).
@@ -1532,7 +1532,7 @@ TO may be one of the following:
   T       --- The system is migrated to its current system version.
   version --- The system is migrated to this specific version.
 
-When this function is called it determines the list of effective
+When this function is called it determines the list of concrete
 versions in the range of the specified FROM and TO versions.
 It then calls MIGRATE-VERSION on the system and each pair of
 versions in the computed range. For instance, if the list of

--- a/documentation.lisp
+++ b/documentation.lisp
@@ -1485,7 +1485,7 @@ See MIGRATE")
 
 By default this will call READY-DEPENDENCY-FOR-MIGRATION on all
 systems that are recorded in the system's defsystem-dependencies
-and regular dependencies.
+and regular dependencies, AND are virtual-module systems.
 
 The user should supply methods on this function in case it is
 necessary to perform actions on other systems for the migration

--- a/documentation.lisp
+++ b/documentation.lisp
@@ -283,6 +283,24 @@ systems.
 
 See RADIANCE-WARNING")
 
+  (type system-has-no-version
+    "Error signalled when an ASDF system does not store a version string.
+
+Without a version string, Radiance is incapable of tracking what the
+current version of a system is and is thus unable to automatically
+migrate it.
+
+This error should be continuable.
+
+See MIGRATE
+See RADIANCE-ERROR")
+
+  (type backwards-migration-not-allowed
+    "Error signalled when a migration from a later version to an earlier version is attempted.
+
+See MIGRATE
+See RADIANCE-ERROR")
+
   (type environment-not-set
     "Error signalled when an action was performed that requires an initialised environment, but no environment has been configured yet.
 

--- a/documentation.lisp
+++ b/documentation.lisp
@@ -1320,6 +1320,10 @@ First ensures both versions are of equal length, then calls
 VERSION-PART= on each part of the versions. If they are all
 VERSION-PART=, then T is returned and NIL otherwise.
 
+A special exemption is made for NIL version specs. If both
+versions are NIL, T is returned. Otherwise, if only one spec is
+NIL, NIL is returned.
+
 See ENSURE-VERSIONS-COMPARABLE
 See VERSION-PART=")
 
@@ -1331,6 +1335,10 @@ VERSION-PART= on each part of the versions. If it returns NIL,
 then VERSION-PART< is called. If this returns T, T is returned,
 otherwise NIL is returned. If all parts are VERSION-PART=, NIL is
 returned.
+
+A special exemption is made for NIL version specs. If both
+versions are NIL, NIL is returned. Otherwise, if the first spec
+is NIL, T is returned. If the second spec is NIL, NIL is returned.
 
 See ENSURE-VERSIONS-COMPARABLE
 See VERSION-PART=
@@ -1344,6 +1352,10 @@ VERSION-PART= on each part of the versions. If it returns NIL,
 then VERSION-PART< is called. If this returns T, T is returned,
 otherwise NIL is returned. If all parts are VERSION-PART=, T is
 returned.
+
+A special exemption is made for NIL version specs. If both
+versions are NIL, T is returned. Otherwise, if the first spec
+is NIL, T is returned. If the second spec is NIL, NIL is returned.
 
 See ENSURE-VERSIONS-COMPARABLE
 See VERSION-PART=

--- a/documentation.lisp
+++ b/documentation.lisp
@@ -1539,9 +1539,24 @@ versions in the computed range. For instance, if the list of
 versions is (1 2 3 4), then MIGRATE-VERSION is called with the
 pairs (1 2) (2 3) (3 4).
 
+If the target version is T and the system has no recorded version,
+an error of type SYSTEM-HAS-NO-VERSION is signalled. If the target
+version is considered less than the source version, an error of
+type BACKWARDS-MIGRATION-NOT-ALLOWED is signalled.
+
+Two restarts are established during migration:
+  ABORT         --- Aborts migration of the current system,
+                    leaving the last known system version the
+                    same.
+  FORCE-VERSION --- Aborts the migration of the current system,
+                    but forces the last known system version to
+                    the requested target version.
+
 See ENSURE-PARSED-VERSION
 See VERSIONS
-See MIGRATE-VERSION"))
+See MIGRATE-VERSION
+See SYSTEM-HAS-NO-VERSION
+See BACKWARDS-MIGRATION-NOT-ALLOWED"))
 
 ;; modules.lisp
 (docs:define-docs

--- a/interface-components.lisp
+++ b/interface-components.lisp
@@ -19,10 +19,11 @@
        (define-hook-switch ,on ,off ,args))))
 
 (define-component-expander define-resource-locator (interface type args)
-  `(define-resource-locator ,(package-name interface) ,type ,args
-     (declare (ignore ,@(lambda-fiddle:extract-lambda-vars args)))
-     (error "Resource locator ~a not implemented for interface ~a!"
-            ,(string-upcase type) ,(package-name interface))))
+  `(unless (modularize-interfaces:implementation ,interface)
+     (define-resource-locator ,(package-name interface) ,type ,args
+       (declare (ignore ,@(lambda-fiddle:extract-lambda-vars args)))
+       (error "Resource locator ~a not implemented for interface ~a!"
+              ,(string-upcase type) ,(package-name interface)))))
 
 (define-component-expander define-option-type (interface name)
   `',(or (find-symbol (string name) interface)

--- a/interfaces.lisp
+++ b/interfaces.lisp
@@ -40,6 +40,10 @@
          (funcall ,symbol ,@args)))))
 
 (defmethod asdf:perform :after ((op asdf:load-op) (virtual-module virtual-module))
+  ;; Trigger potential migrations if we're already started up.
+  (when *running*
+    (migrate virtual-module T T))
+  ;; Register implementations
   (loop for interface in (module-storage (module (virtual-module-name virtual-module)) :implements)
         do (trigger (find-symbol (string :implemented) (interface interface)))
            (future l debug :interfaces "~a now implemented by ~a" (module-name interface) (module-name (virtual-module-name virtual-module)))))

--- a/interfaces.lisp
+++ b/interfaces.lisp
@@ -89,7 +89,8 @@
             #-quicklisp
             (asdf:load-system implementation)
             #+:quicklisp
-            (ql:quickload implementation)))))))
+            (ql:quickload implementation))
+          implementation)))))
 
 (defmacro define-interface (name &body components)
   `(interfaces:define-interface ,name

--- a/interfaces.lisp
+++ b/interfaces.lisp
@@ -27,7 +27,7 @@
 
 (if (find-symbol "RESOLVE-DEPENDENCY-COMBINATION" :asdf)
     (eval
-     `(defmethod ,(find-symbol "RESOLVE-DEPENDENCY-COMBINATION" :asdf) ((virtual-module virtual-module) (combinator (eql :interface)) args)
+     `(defmethod ,(find-symbol "RESOLVE-DEPENDENCY-COMBINATION" :asdf) (system (combinator (eql :interface)) args)
         (find-implementation (first args))))
     (error "Radiance cannot support this version of ASDF. Sorry!"))
 

--- a/migrate.lisp
+++ b/migrate.lisp
@@ -184,7 +184,10 @@
 (define-version-migration (:radiance-core NIL :2.0.0)
   (let ((previous-config-directory (merge-pathnames "radiance/" (ubiquitous:config-directory))))
     (when (uiop:directory-exists-p previous-config-directory)
+      (l:info :radiance.migrate "Migrating previous configuration from ~a."
+              previous-config-directory)
       (loop for original-path in (uiop:subdirectories previous-config-directory)
             for environment = (car (last (pathname-directory environment)))
             for new-path = (environment-directory environment :configuration)
-            do (rename-file original-path new-path)))))
+            do (rename-file original-path new-path))
+      (uiop:delete-empty-directory previous-config-directory))))

--- a/migrate.lisp
+++ b/migrate.lisp
@@ -120,9 +120,13 @@
         #'version<))
 
 (defmethod migrate (module from to)
-  (let ((versions (version-bounds (versions module) :start from :end to)))
-    (loop for (from to) on versions
-          do (migrate-versions module from to))))
+  (unless (version= from to)
+    (assert (version< from to) (from to)
+            "Cannot migrate backwards from ~s to ~s."
+            (encode-version from) (encode-version to))
+    (let ((versions (version-bounds (versions module) :start from :end to)))
+      (loop for (from to) on versions
+            do (migrate-versions module from to)))))
 
 (defmethod migrate (module from (to (eql T)))
   (let* ((virtual (virtual-module module))

--- a/migrate.lisp
+++ b/migrate.lisp
@@ -1,0 +1,136 @@
+#|
+ This file is a part of Radiance
+ (c) 2016 Shirakumo http://tymoon.eu (shinmera@tymoon.eu)
+ Author: Nicolas Hafner <shinmera@tymoon.eu>
+|#
+
+(in-package #:org.shirakumo.radiance.core)
+
+(defun encode-version (version)
+  (etypecase version
+    (keyword version)
+    (string (intern version :KEYWORD))
+    (cons (encode-version
+           (with-output-to-string (out)
+             (princ (first version) out)
+             (dolist (part (rest version))
+               (etypecase part
+                 (integer (format out ".~d" part))
+                 (string (format out "-~:@(~a~)" part)))))))))
+
+(defun parse-version (version)
+  (loop for part in (cl-ppcre:split "[.-]" version)
+        collect (or (ignore-errors (parse-integer part))
+                    part)))
+
+(defun ensure-parsed-version (version)
+  (etypecase version
+    (cons version)
+    ((or string keyword)
+     (parse-version (string version)))))
+
+(defun ensure-versions-comparable (a b)
+  (let* ((a (ensure-parsed-version a))
+         (b (ensure-parsed-version b))
+         (al (length a))
+         (bl (length b)))
+    (cond ((< al bl)
+           (values (append a (make-list (- bl al) :initial-element 0))
+                   b))
+          ((< bl al)
+           (values a
+                   (append b (make-list (- al bl) :initial-element 0))))
+          (T
+           (values a b)))))
+
+(defmethod version-part= ((a integer) (b integer)) (= a b))
+(defmethod version-part= ((a integer) (b string))  NIL)
+(defmethod version-part= ((a string)  (b integer)) NIL)
+(defmethod version-part= ((a string)  (b string))  (string= a b))
+(defmethod version-part< ((a integer) (b integer)) (< a b))
+(defmethod version-part< ((a integer) (b string))  T)
+(defmethod version-part< ((a string)  (b integer)) NIL)
+(defmethod version-part< ((a string)  (b string))  (string< a b))
+
+(defun version= (a b)
+  (multiple-value-bind (a-parts b-parts) (ensure-versions-comparable a b)
+    (loop for a in a-parts
+          for b in b-parts
+          always (version-part= a b))))
+
+(defun version< (a b)
+  (multiple-value-bind (a-parts b-parts) (ensure-versions-comparable a b)
+    (loop for a in a-parts
+          for b in b-parts
+          do (cond ((version-part= a b))
+                   ((version-part< a b) (return T))
+                   (T                   (return NIL)))
+          finally (return NIL))))
+
+(defun version<= (a b)
+  (multiple-value-bind (a-parts b-parts) (ensure-versions-comparable a b)
+    (loop for a in a-parts
+          for b in b-parts
+          do (cond ((version-part= a b))
+                   ((version-part< a b) (return T))
+                   (T                   (return NIL)))
+          finally (return T))))
+
+(defun version-region (versions &key start end)
+  (loop for version in versions
+        when (and (or (not start) (version<= start version))
+                  (or (not end) (version<= version end)))
+        collect version))
+
+(defun version-bounds (versions &key start end)
+  (let* ((versions (version-region versions :start start :end end))
+         (last (last versions)))
+    (when (and start (version< start (first versions)))
+      (push start versions))
+    (when (and end (version< (car last) end))
+      (setf (cdr last) (list end)))
+    versions))
+
+(defmethod last-known-module-version (module)
+  (config :versions (module-name module)))
+
+(defmethod (setf last-known-module-version) (version module)
+  (config :versions (module-name module) (encode-version version)))
+
+(defgeneric migrate-versions (module from to))
+
+(defmethod migrate-versions (module from to)
+  :ignored)
+
+(defmethod migrate-versions :after (module from to)
+  (setf (last-known-module-version module) to))
+
+(defun versions (module)
+  (sort (remove-duplicates
+         (loop for method in (c2mop:generic-function-methods #'migrate-versions)
+               for (mod from to) = (c2mop:method-specializers method)
+               for matching = (and (null (method-qualifiers method))
+                                   (typep mod 'c2mop:eql-specializer)
+                                   (eql module (c2mop:eql-specializer-object mod)))
+               when (and matching (typep from 'c2mop:eql-specializer))
+               collect (c2mop:eql-specializer-object from)
+               when (and matching (typep to 'c2mop:eql-specializer))
+               collect (c2mop:eql-specializer-object to))
+         :test #'version=)
+        #'version<))
+
+(defmethod migrate (module from to)
+  (let ((versions (version-bounds (versions module) :start from :end to)))
+    (loop for (from to) on versions
+          do (migrate-versions module from to))))
+
+(defmethod migrate (module from (to (eql T)))
+  (let* ((virtual (virtual-module module))
+         (version (or (module-storage module :version)
+                      (when virtual (asdf:component-version version)))))
+    (if version
+        (migrate module from version)
+        (error 'module-has-no-version :module module))))
+
+(defmethod migrate (module (from (eql T)) to)
+  (migrate module (last-known-module-version module) to))

--- a/migrate.lisp
+++ b/migrate.lisp
@@ -124,6 +124,7 @@
     (assert (version< from to) (from to)
             "Cannot migrate backwards from ~s to ~s."
             (encode-version from) (encode-version to))
+    ;; FIXME: Ensure upgraded deps
     (let ((versions (version-bounds (versions module) :start from :end to)))
       (loop for (from to) on versions
             do (migrate-versions module from to)))))
@@ -138,3 +139,12 @@
 
 (defmethod migrate (module (from (eql T)) to)
   (migrate module (last-known-module-version module) to))
+
+
+(defmethod migrate-version ((module (eql #.*package*)) (from null) (to (eql :2.0.0)))
+  (let ((previous-config-directory (merge-pathnames "radiance/" (ubiquitous:config-directory))))
+    (when (uiop:directory-exists-p previous-config-directory)
+      (loop for original-path in (uiop:subdirectories previous-config-directory)
+            for environment = (car (last (pathname-directory environment)))
+            for new-path = (environment-directory environment :configuration)
+            do (rename-file original-path new-path)))))

--- a/migration.lisp
+++ b/migration.lisp
@@ -128,16 +128,17 @@
 
 (defmethod ready-dependency-for-migration (dependency system from)
   (declare (ignore system from))
-  (migrate dependency T T))
+  (handler-bind ((system-has-no-version #'continue))
+    (migrate dependency T T)))
 
 (defmethod ensure-dependencies-ready ((system asdf:system) from)
-  (loop for spec = (append (asdf:system-defsystem-depends-on system)
-                           (asdf:system-depends-on system))
+  (loop for spec in (append (asdf:system-defsystem-depends-on system)
+                            (asdf:system-depends-on system))
         for dependency = (ensure-system spec system)
         do (ready-dependency-for-migration dependency system from)))
 
 (defmethod migrate-versions :before (system from to)
-  (l:debug :radiance.migration "Migrating ~s from ~a to ~a."
+  (l:debug :radiance.migration "Migrating ~a from ~a to ~a."
            (asdf:component-name system) (encode-version from) (encode-version to))
   (ensure-dependencies-ready system from))
 

--- a/migration.lisp
+++ b/migration.lisp
@@ -126,6 +126,8 @@
         do (ready-dependency-for-migration dependency system from)))
 
 (defmethod migrate-versions :before (system from to)
+  (l:debug :radiance.migration "Migrating ~s from ~a to ~a."
+           (asdf:component-name system) (encode-version from) (encode-version to))
   (ensure-dependencies-ready system from))
 
 (defmethod migrate-versions (system from to))
@@ -165,6 +167,8 @@
     (assert (version< from to) (from to)
             "Cannot migrate backwards from ~s to ~s."
             (encode-version from) (encode-version to))
+    (l:info :radiance.migration "Migrating ~s from ~a to ~a."
+            (asdf:component-name system) (encode-version from) (encode-version to))
     (let ((versions (version-bounds (versions system) :start from :end to)))
       (loop for (from to) on versions
             do (migrate-versions system from to)))))

--- a/migration.lisp
+++ b/migration.lisp
@@ -93,13 +93,14 @@
         collect version))
 
 (defun version-bounds (versions &key (start NIL start-p) end)
-  (let* ((versions (version-region versions :start start :end end))
-         (last (last versions)))
-    (when (and start-p (version< start (first versions)))
-      (push start versions))
-    (when (and end (version< (car last) end))
-      (setf (cdr last) (list end)))
-    versions))
+  (when versions
+    (let* ((versions (version-region versions :start start :end end))
+           (last (last versions)))
+      (when (and start-p (version< start (first versions)))
+        (push start versions))
+      (when (and end (version< (car last) end))
+        (setf (cdr last) (list end)))
+      versions)))
 
 (defmethod last-known-system-version ((system asdf:system))
   (config :versions (asdf:component-name system)))

--- a/migration.lisp
+++ b/migration.lisp
@@ -107,17 +107,6 @@
      (asdf/find-component:resolve-dependency-spec
       parent system-ish))))
 
-(defun traverse-system-dependencies (system function)
-  (let ((cache (make-hash-table :test 'eq)))
-    (labels ((traverse (system)
-               (unless (gethash system cache)
-                 (setf (gethash system cache) T)
-                 (dolist (subsystem (append (asdf:system-defsystem-depends-on system)
-                                            (asdf:system-depends-on system)))
-                   (traverse (ensure-system subsystem system)))
-                 (funcall function system))))
-      (traverse system))))
-
 (defgeneric migrate-versions (system from to))
 
 (defmethod migrate-versions (system from to))

--- a/migration.lisp
+++ b/migration.lisp
@@ -182,7 +182,7 @@
             do (migrate-versions system from to)))))
 
 (defmethod migrate ((system asdf:system) from (to (eql T)))
-  (let ((version (asdf:component-version version)))
+  (let ((version (asdf:component-version system)))
     (if version
         (migrate system from version)
         (error 'system-has-no-version :system system))))

--- a/migration.lisp
+++ b/migration.lisp
@@ -135,7 +135,8 @@
   (loop for spec in (append (asdf:system-defsystem-depends-on system)
                             (asdf:system-depends-on system))
         for dependency = (ensure-system spec system)
-        do (ready-dependency-for-migration dependency system from)))
+        do (when (typep dependency 'virtual-module)
+             (ready-dependency-for-migration dependency system from))))
 
 (defmethod migrate-versions :before (system from to)
   (l:debug :radiance.migration "Migrating ~a from ~a to ~a."

--- a/module.lisp
+++ b/module.lisp
@@ -72,6 +72,8 @@
    #:radiance-condition
    #:message
    #:definition-for-shared-package
+   #:system-has-no-version
+   #:backwards-migration-not-allowed
    #:environment-not-set
    #:internal-error
    #:request-error

--- a/module.lisp
+++ b/module.lisp
@@ -173,6 +173,15 @@
    #:load-implementation
    #:define-interface
    #:define-implement-trigger)
+  ;; migration.lisp
+  (:export
+   #:last-known-system-version
+   #:migrate-versions
+   #:define-version-migration
+   #:ready-dependency-for-migration
+   #:ensure-dependencies-ready
+   #:versions
+   #:migrate)
   ;; modules.lisp
   (:export
    #:module-domain

--- a/radiance-core.asd
+++ b/radiance-core.asd
@@ -8,7 +8,7 @@
   :class "modularize:virtual-module"
   :defsystem-depends-on (:modularize)
   :module-name "RADIANCE-CORE"
-  :version "1.5.0"
+  :version "2.0.0"
   :license "Artistic"
   :author "Nicolas Hafner <shinmera@tymoon.eu>"
   :maintainer "Nicolas Hafner <shinmera@tymoon.eu>"
@@ -21,7 +21,6 @@
                (:file "environment")
                (:file "interfaces")
                (:file "modules")
-               (:file "migration")
                (:file "uri")
                (:file "resource")
                (:file "routing")
@@ -34,6 +33,7 @@
                (:file "standard-interfaces")
                (:file "handle")
                (:file "defaults")
+               (:file "migration")
                (:file "init")
                (:file "version-upgrades")
                (:file "documentation"))

--- a/radiance-core.asd
+++ b/radiance-core.asd
@@ -21,6 +21,7 @@
                (:file "environment")
                (:file "interfaces")
                (:file "modules")
+               (:file "migration")
                (:file "uri")
                (:file "resource")
                (:file "routing")
@@ -46,5 +47,6 @@
                :form-fiddle
                :bordeaux-threads
                :documentation-utils
-               :babel)
+               :babel
+               :closer-mop)
   :in-order-to ((asdf:test-op (asdf:test-op :radiance-test))))

--- a/radiance-core.asd
+++ b/radiance-core.asd
@@ -35,6 +35,7 @@
                (:file "handle")
                (:file "defaults")
                (:file "init")
+               (:file "version-upgrades")
                (:file "documentation"))
   :depends-on (:modularize-hooks
                :modularize-interfaces

--- a/radiance.asd
+++ b/radiance.asd
@@ -5,7 +5,7 @@
 |#
 
 (asdf:defsystem radiance
-  :version "1.5.0"
+  :version "2.0.0"
   :license "Artistic"
   :author "Nicolas Hafner <shinmera@tymoon.eu>"
   :maintainer "Nicolas Hafner <shinmera@tymoon.eu>"

--- a/version-upgrades.lisp
+++ b/version-upgrades.lisp
@@ -9,15 +9,21 @@
 (define-version-migration radiance-core (NIL 2.0.0)
   (let ((previous-config-directory (merge-pathnames "radiance/" (ubiquitous:config-directory))))
     (when (uiop:directory-exists-p previous-config-directory)
-      (l:info :radiance.migration "Migrating previous configuration from ~a."
+      (l:info :radiance.migration "Migrating previous configuration from ~a"
               previous-config-directory)
       (loop for original-path in (uiop:subdirectories previous-config-directory)
             for environment = (car (last (pathname-directory original-path)))
             for new-path = (environment-directory environment :configuration)
+            for temp-path = (make-pathname :directory (append (butlast (pathname-directory new-path))
+                                                              (list (format NIL "before-migration-~a" environment)))
+                                           :defaults new-path)
             do (when (uiop:directory-exists-p new-path)
-                 (rename-file new-path
-                              (make-pathname :directory (append (butlast (pathname-directory new-path))
-                                                                (list (format NIL "before-migration-~a" environment)))
-                                             :defaults new-path)))
-               (rename-file original-path new-path))
+                 (rename-file new-path temp-path)
+                 (l:info :radiance.migration "The existing configuration for the ~s environment has been moved to~%  ~a"
+                         environment temp-path))
+               (rename-file original-path new-path)
+               (when (string= environment (environment))
+                 (l:info :radiance.migration "Restored current environment ~s from old site, reloading."
+                         environment)
+                 (reload-environment)))
       (uiop:delete-empty-directory previous-config-directory))))

--- a/version-upgrades.lisp
+++ b/version-upgrades.lisp
@@ -9,10 +9,15 @@
 (define-version-migration radiance-core (NIL 2.0.0)
   (let ((previous-config-directory (merge-pathnames "radiance/" (ubiquitous:config-directory))))
     (when (uiop:directory-exists-p previous-config-directory)
-      (l:info :radiance.migrate "Migrating previous configuration from ~a."
+      (l:info :radiance.migration "Migrating previous configuration from ~a."
               previous-config-directory)
       (loop for original-path in (uiop:subdirectories previous-config-directory)
-            for environment = (car (last (pathname-directory environment)))
+            for environment = (car (last (pathname-directory original-path)))
             for new-path = (environment-directory environment :configuration)
-            do (rename-file original-path new-path))
+            do (when (uiop:directory-exists-p new-path)
+                 (rename-file new-path
+                              (make-pathname :directory (append (butlast (pathname-directory new-path))
+                                                                (list (format NIL "before-migration-~a" environment)))
+                                             :defaults new-path)))
+               (rename-file original-path new-path))
       (uiop:delete-empty-directory previous-config-directory))))

--- a/version-upgrades.lisp
+++ b/version-upgrades.lisp
@@ -1,0 +1,18 @@
+#|
+ This file is a part of Radiance
+ (c) 2016 Shirakumo http://tymoon.eu (shinmera@tymoon.eu)
+ Author: Nicolas Hafner <shinmera@tymoon.eu>
+|#
+
+(in-package #:org.shirakumo.radiance.core)
+
+(define-version-migration radiance-core (NIL 2.0)
+  (let ((previous-config-directory (merge-pathnames "radiance/" (ubiquitous:config-directory))))
+    (when (uiop:directory-exists-p previous-config-directory)
+      (l:info :radiance.migrate "Migrating previous configuration from ~a."
+              previous-config-directory)
+      (loop for original-path in (uiop:subdirectories previous-config-directory)
+            for environment = (car (last (pathname-directory environment)))
+            for new-path = (environment-directory environment :configuration)
+            do (rename-file original-path new-path))
+      (uiop:delete-empty-directory previous-config-directory))))

--- a/version-upgrades.lisp
+++ b/version-upgrades.lisp
@@ -6,7 +6,7 @@
 
 (in-package #:org.shirakumo.radiance.core)
 
-(define-version-migration radiance-core (NIL 2.0)
+(define-version-migration radiance-core (NIL 2.0.0)
   (let ((previous-config-directory (merge-pathnames "radiance/" (ubiquitous:config-directory))))
     (when (uiop:directory-exists-p previous-config-directory)
       (l:info :radiance.migrate "Migrating previous configuration from ~a."


### PR DESCRIPTION
This implements a relatively simple migration system for Radiance and its users that allows the migration of runtime data to accomodate for incompatible changes. This should fix #30.

Yet To Do:
* [x] Hook the migration step into the startup sequence
* [x] Document usage in the README